### PR TITLE
Fix BUG-005 preserve selected platform on Learn page

### DIFF
--- a/src/pages/LearnPage.tsx
+++ b/src/pages/LearnPage.tsx
@@ -664,8 +664,14 @@ export function LearnPage() {
     []
   );
 
-  const [selectedPlatform, setSelectedPlatform] = useState<string>(platforms[0]?.id ?? 'lovable');
-
+const [selectedPlatform, setSelectedPlatform] = useState<string>(() => {
+  try {
+    const saved = typeof window !== 'undefined' ? window.localStorage.getItem('learn:selectedPlatform') : null;
+    return saved || platforms[0]?.id || 'lovable';
+  } catch {
+    return platforms[0]?.id || 'lovable';
+  }
+});
   const [filtersMode, setFiltersMode] = useState<'on' | 'off'>(() => {
     try {
       // New key
@@ -707,6 +713,14 @@ export function LearnPage() {
       // ignore
     }
   }, [filtersMode]);
+  
+  useEffect(() => {
+  try {
+    window.localStorage.setItem('learn:selectedPlatform', selectedPlatform);
+  } catch {
+    // ignore
+  }
+}, [selectedPlatform]);
 
   const scrollToPlatform = (platformId: string) => {
     setSelectedPlatform(platformId);


### PR DESCRIPTION
Fixed the Learn page state reset issue by persisting the selected platform in localStorage and restoring it when the page is revisited after opening a tutorial in a new tab.