### PR TITLE
feat: add multi-page onboarding tooltip tours

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { ForgotPasswordPage } from '@/pages/ForgotPasswordPage';
 import { ResetPasswordPage } from '@/pages/ResetPasswordPage';
 import OnboardingStepPage from '@/pages/onboarding/[step]';
 import { OnboardingCompleteScreen } from '@/components/OnboardingCompleteScreen';
+import { OnboardingTour } from '@/components/onboarding/OnboardingTour';
 import './App.css';
 
 function AppRoutes() {
@@ -123,6 +124,7 @@ function App() {
         <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black">
           <Navigation />
           <AppRoutes />
+          <OnboardingTour />
           <Toaster />
         </div>
       </Router>

--- a/src/components/onboarding/OnboardingTooltip.tsx
+++ b/src/components/onboarding/OnboardingTooltip.tsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
+import type { OnboardingStep } from './onboardingSteps';
+
+interface TooltipPosition {
+  top: number;
+  left: number;
+  width: number;
+  placement: 'top' | 'bottom';
+}
+
+interface OnboardingTooltipProps {
+  step: OnboardingStep;
+  currentStep: number;
+  totalSteps: number;
+  position: TooltipPosition;
+  onBack: () => void;
+  onNext: () => void;
+  onSkipAll: () => void;
+}
+
+export function OnboardingTooltip({
+  step,
+  currentStep,
+  totalSteps,
+  position,
+  onBack,
+  onNext,
+  onSkipAll,
+}: OnboardingTooltipProps) {
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
+  const titleId = `onboarding-title-${currentStep}`;
+  const descriptionId = `onboarding-description-${currentStep}`;
+  const isLastStep = currentStep === totalSteps - 1;
+  const progress = ((currentStep + 1) / totalSteps) * 100;
+  const stepsRemaining = Math.max(totalSteps - currentStep - 1, 0);
+
+  const focusableSelector = useMemo(
+    () =>
+      [
+        'a[href]',
+        'button:not([disabled])',
+        'textarea:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])',
+      ].join(', '),
+    []
+  );
+
+  useEffect(() => {
+    const tooltip = tooltipRef.current;
+    if (!tooltip) return;
+
+    const focusable = Array.from(tooltip.querySelectorAll<HTMLElement>(focusableSelector));
+    const first = focusable[0] ?? tooltip;
+    first.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onSkipAll();
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const currentFocusable = Array.from(tooltip.querySelectorAll<HTMLElement>(focusableSelector));
+      if (currentFocusable.length === 0) {
+        event.preventDefault();
+        tooltip.focus();
+        return;
+      }
+
+      const firstElement = currentFocusable[0];
+      const lastElement = currentFocusable[currentFocusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    tooltip.addEventListener('keydown', handleKeyDown);
+    return () => tooltip.removeEventListener('keydown', handleKeyDown);
+  }, [currentStep, focusableSelector, onSkipAll]);
+
+  return (
+    <div
+      ref={tooltipRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      tabIndex={-1}
+      className={cn(
+        'onboarding-tooltip fixed z-[120] rounded-lg border border-[var(--color-border)] bg-[var(--color-card)] text-[var(--color-text)] shadow-2xl outline-none',
+        'transition-all duration-300 ease-out',
+        position.placement === 'top' ? 'animate-onboarding-slide-up' : 'animate-onboarding-slide-down'
+      )}
+      style={{
+        top: position.top,
+        left: position.left,
+        width: position.width,
+      }}
+    >
+      <div className="space-y-3 p-3 sm:p-4">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-3 text-xs font-medium text-gray-400">
+            <span>
+              Step {currentStep + 1} of {totalSteps}
+            </span>
+            <span aria-live="polite">
+              {stepsRemaining === 0 ? 'Last step' : `${stepsRemaining} remaining`}
+            </span>
+          </div>
+          <Progress value={progress} className="h-1.5" aria-label="Tour progress" />
+        </div>
+
+        <div>
+          <h2 id={titleId} className="mb-1.5 text-base font-semibold leading-tight text-white">
+            {step.title}
+          </h2>
+          <p id={descriptionId} className="mb-0 text-xs leading-5 text-gray-300 sm:text-sm">
+            {step.description}
+          </p>
+        </div>
+
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onSkipAll}
+            aria-label="Skip all onboarding tours"
+          >
+            Skip All
+          </Button>
+
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={onBack}
+              disabled={currentStep === 0}
+              aria-label="Go to previous onboarding step"
+            >
+              Back
+            </Button>
+            <Button type="button" size="sm" onClick={onNext} aria-label={isLastStep ? 'Finish tour' : 'Go to next step'}>
+              {isLastStep ? 'Finish' : 'Next'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -1,0 +1,284 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useLocation } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import { OnboardingTooltip } from './OnboardingTooltip';
+import { getOnboardingPageKey, onboardingSteps, type OnboardingPageKey } from './onboardingSteps';
+import {
+  ONBOARDING_RESTART_EVENT,
+  readOnboardingProgress,
+  skipOnboardingPage,
+  writeOnboardingProgress,
+} from './onboardingStorage';
+
+interface SpotlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface TooltipPosition {
+  top: number;
+  left: number;
+  width: number;
+  placement: 'top' | 'bottom';
+}
+
+const SPOTLIGHT_PADDING = 8;
+const TOOLTIP_GAP = 16;
+const TOOLTIP_MAX_WIDTH = 340;
+const TOOLTIP_ESTIMATED_HEIGHT = 230;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getSpotlightRect(target: Element): SpotlightRect {
+  const rect = target.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  const top = clamp(rect.top - SPOTLIGHT_PADDING, 8, viewportHeight - 16);
+  const left = clamp(rect.left - SPOTLIGHT_PADDING, 8, viewportWidth - 16);
+  const right = clamp(rect.right + SPOTLIGHT_PADDING, 16, viewportWidth - 8);
+  const bottom = clamp(rect.bottom + SPOTLIGHT_PADDING, 16, viewportHeight - 8);
+
+  return {
+    top,
+    left,
+    width: Math.max(right - left, 1),
+    height: Math.max(bottom - top, 1),
+  };
+}
+
+function getTooltipPosition(spotlight: SpotlightRect): TooltipPosition {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const width = Math.min(TOOLTIP_MAX_WIDTH, viewportWidth - 32);
+  const centeredLeft = spotlight.left + spotlight.width / 2 - width / 2;
+  const left = clamp(centeredLeft, 16, viewportWidth - width - 16);
+  const hasRoomBelow = spotlight.top + spotlight.height + TOOLTIP_GAP + TOOLTIP_ESTIMATED_HEIGHT < viewportHeight;
+  const placement = hasRoomBelow ? 'bottom' : 'top';
+  const preferredTop = hasRoomBelow
+    ? spotlight.top + spotlight.height + TOOLTIP_GAP
+    : spotlight.top - TOOLTIP_GAP - TOOLTIP_ESTIMATED_HEIGHT;
+
+  return {
+    top: clamp(preferredTop, 16, Math.max(16, viewportHeight - TOOLTIP_ESTIMATED_HEIGHT - 16)),
+    left,
+    width,
+    placement,
+  };
+}
+
+export function OnboardingTour() {
+  const location = useLocation();
+  const { user } = useAuth();
+  const pageKey = useMemo(() => getOnboardingPageKey(location.pathname), [location.pathname]);
+  const [activePage, setActivePage] = useState<OnboardingPageKey | null>(null);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [spotlight, setSpotlight] = useState<SpotlightRect | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  const steps = activePage ? onboardingSteps[activePage] : [];
+  const step = steps[currentStep];
+  const isActive = Boolean(user && activePage && step);
+
+  const startPageTour = useCallback(
+    (nextPageKey: OnboardingPageKey) => {
+      if (!user) return;
+
+      const saved = readOnboardingProgress(user.id, nextPageKey);
+      if (saved?.status === 'completed' || saved?.status === 'skipped') {
+        setActivePage(null);
+        return;
+      }
+
+      const totalSteps = onboardingSteps[nextPageKey].length;
+      const savedStep =
+        saved?.status === 'in-progress' ? clamp(saved.currentStep, 0, Math.max(totalSteps - 1, 0)) : 0;
+
+      setActivePage(nextPageKey);
+      setCurrentStep(savedStep);
+      writeOnboardingProgress(user.id, nextPageKey, {
+        status: 'in-progress',
+        currentStep: savedStep,
+      });
+    },
+    [user]
+  );
+
+  useEffect(() => {
+    setSpotlight(null);
+    setTooltipPosition(null);
+
+    if (!user || !pageKey) {
+      setActivePage(null);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => startPageTour(pageKey), 250);
+    return () => window.clearTimeout(timeoutId);
+  }, [pageKey, startPageTour, user]);
+
+  useEffect(() => {
+    const handleRestart = () => {
+      if (!pageKey) return;
+      setActivePage(pageKey);
+      setCurrentStep(0);
+      setRefreshTick((tick) => tick + 1);
+      if (user) {
+        writeOnboardingProgress(user.id, pageKey, {
+          status: 'in-progress',
+          currentStep: 0,
+        });
+      }
+    };
+
+    window.addEventListener(ONBOARDING_RESTART_EVENT, handleRestart);
+    return () => window.removeEventListener(ONBOARDING_RESTART_EVENT, handleRestart);
+  }, [pageKey, user]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isActive]);
+
+  const measureCurrentTarget = useCallback(() => {
+    if (!step) return;
+
+    const target = document.querySelector(step.target);
+    if (!target) {
+      setSpotlight(null);
+      setTooltipPosition(null);
+      return;
+    }
+
+    const rect = getSpotlightRect(target);
+    setSpotlight(rect);
+    setTooltipPosition(getTooltipPosition(rect));
+  }, [step]);
+
+  useEffect(() => {
+    if (!isActive || !step) return;
+
+    const target = document.querySelector(step.target);
+    target?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+
+    const firstMeasure = window.setTimeout(measureCurrentTarget, 180);
+    const interval = window.setInterval(measureCurrentTarget, 300);
+
+    window.addEventListener('resize', measureCurrentTarget);
+    window.addEventListener('scroll', measureCurrentTarget, true);
+
+    return () => {
+      window.clearTimeout(firstMeasure);
+      window.clearInterval(interval);
+      window.removeEventListener('resize', measureCurrentTarget);
+      window.removeEventListener('scroll', measureCurrentTarget, true);
+    };
+  }, [currentStep, isActive, measureCurrentTarget, refreshTick, step]);
+
+  const completePageTour = useCallback(() => {
+    if (!user || !activePage) return;
+    writeOnboardingProgress(user.id, activePage, {
+      status: 'completed',
+      currentStep: onboardingSteps[activePage].length - 1,
+    });
+    setActivePage(null);
+  }, [activePage, user]);
+
+  const handleNext = useCallback(() => {
+    if (!user || !activePage) return;
+
+    if (currentStep >= steps.length - 1) {
+      completePageTour();
+      return;
+    }
+
+    const nextStep = currentStep + 1;
+    setCurrentStep(nextStep);
+    writeOnboardingProgress(user.id, activePage, {
+      status: 'in-progress',
+      currentStep: nextStep,
+    });
+  }, [activePage, completePageTour, currentStep, steps.length, user]);
+
+  const handleBack = useCallback(() => {
+    if (!user || !activePage) return;
+
+    const previousStep = Math.max(currentStep - 1, 0);
+    setCurrentStep(previousStep);
+    writeOnboardingProgress(user.id, activePage, {
+      status: 'in-progress',
+      currentStep: previousStep,
+    });
+  }, [activePage, currentStep, user]);
+
+  const handleSkipAll = useCallback(() => {
+    if (!user || !activePage) return;
+    skipOnboardingPage(user.id, activePage, currentStep);
+    setActivePage(null);
+  }, [activePage, currentStep, user]);
+
+  if (!isActive || !spotlight || !tooltipPosition || !step) {
+    return null;
+  }
+
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const topHeight = Math.max(spotlight.top, 0);
+  const bottomTop = Math.min(spotlight.top + spotlight.height, viewportHeight);
+  const bottomHeight = Math.max(viewportHeight - bottomTop, 0);
+  const middleTop = spotlight.top;
+  const middleHeight = Math.max(spotlight.height, 0);
+  const leftWidth = Math.max(spotlight.left, 0);
+  const rightLeft = Math.min(spotlight.left + spotlight.width, viewportWidth);
+  const rightWidth = Math.max(viewportWidth - rightLeft, 0);
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-[90] cursor-default" aria-hidden="true" />
+      <div className="onboarding-overlay fixed left-0 top-0 z-[91]" style={{ width: viewportWidth, height: topHeight }} />
+      <div
+        className="onboarding-overlay fixed left-0 z-[91]"
+        style={{ top: bottomTop, width: viewportWidth, height: bottomHeight }}
+      />
+      <div
+        className="onboarding-overlay fixed left-0 z-[91]"
+        style={{ top: middleTop, width: leftWidth, height: middleHeight }}
+      />
+      <div
+        className="onboarding-overlay fixed z-[91]"
+        style={{ top: middleTop, left: rightLeft, width: rightWidth, height: middleHeight }}
+        aria-hidden="true"
+      />
+      <div
+        className="onboarding-spotlight fixed z-[92] rounded-lg"
+        style={{
+          top: spotlight.top,
+          left: spotlight.left,
+          width: spotlight.width,
+          height: spotlight.height,
+        }}
+        aria-hidden="true"
+      />
+      <OnboardingTooltip
+        step={step}
+        currentStep={currentStep}
+        totalSteps={steps.length}
+        position={tooltipPosition}
+        onBack={handleBack}
+        onNext={handleNext}
+        onSkipAll={handleSkipAll}
+      />
+    </>,
+    document.body
+  );
+}

--- a/src/components/onboarding/onboardingSteps.ts
+++ b/src/components/onboarding/onboardingSteps.ts
@@ -1,0 +1,152 @@
+export type OnboardingPageKey = 'dashboard' | 'learn' | 'challenges' | 'leaderboard' | 'profile';
+
+export interface OnboardingStep {
+  target: string;
+  title: string;
+  description: string;
+}
+
+export const onboardingPageKeys: OnboardingPageKey[] = [
+  'dashboard',
+  'learn',
+  'challenges',
+  'leaderboard',
+  'profile',
+];
+
+export const onboardingSteps: Record<OnboardingPageKey, OnboardingStep[]> = {
+  dashboard: [
+    {
+      target: '#dashboard-welcome',
+      title: 'Start From Your Home Base',
+      description: 'Use the dashboard to get a quick read on your learning activity and where to jump in next.',
+    },
+    {
+      target: '#xp-card',
+      title: 'Track Your Progress',
+      description: 'View your XP, completed challenges, and progress toward your next learning milestone.',
+    },
+    {
+      target: '#recent-submissions-card',
+      title: 'Review Recent Work',
+      description: 'Check your latest challenge submissions, approval status, and feedback from reviewers.',
+    },
+    {
+      target: '#dashboard-profile-card',
+      title: 'Keep Your Profile Handy',
+      description: 'Open your profile from here to update your details and review your public learning identity.',
+    },
+    {
+      target: '#dashboard-badges-card',
+      title: 'Celebrate Achievements',
+      description: 'Badges highlight the skills and milestones you unlock as you complete more challenges.',
+    },
+  ],
+  learn: [
+    {
+      target: '#learn-header',
+      title: 'Explore Learning Tools',
+      description: 'Browse no-code and AI platforms that can help you prototype, build, and ship faster.',
+    },
+    {
+      target: '#learn-mode-buttons',
+      title: 'Choose Your Browse Mode',
+      description: 'Switch between a simple platform browser and guided filters for more targeted discovery.',
+    },
+    {
+      target: '#learn-path-buttons',
+      title: 'Shape Your Path',
+      description: 'Use filters, AI assist, or learning pathways to narrow tools around your goals and skill level.',
+    },
+    {
+      target: '#learn-platforms',
+      title: 'Compare Platforms',
+      description: 'Scan platform cards for difficulty, pricing, categories, and key features before diving deeper.',
+    },
+    {
+      target: '#learn-selected-tool',
+      title: 'Follow Tutorials',
+      description: 'Open docs and tutorials from the selected tool details when you are ready to learn by doing.',
+    },
+  ],
+  challenges: [
+    {
+      target: '#challenges-header',
+      title: 'Find Practical Challenges',
+      description: 'Challenges turn learning into buildable tasks, with XP and badges tied to completion.',
+    },
+    {
+      target: '#challenge-request-button',
+      title: 'Request New Challenges',
+      description: 'Suggest a challenge when you spot a tool, workflow, or skill the platform should cover next.',
+    },
+    {
+      target: '#challenge-filters-card',
+      title: 'Filter The Challenge List',
+      description: 'Search by topic or narrow by difficulty so you can pick the right next step.',
+    },
+    {
+      target: '#challenge-grid',
+      title: 'Start Building',
+      description: 'Open a challenge card to read the requirements, submit your work, and earn XP.',
+    },
+  ],
+  leaderboard: [
+    {
+      target: '#leaderboard-header',
+      title: 'See The Community Race',
+      description: 'The leaderboard shows how learners rank by XP across the NoCodeJam community.',
+    },
+    {
+      target: '#top-10-card',
+      title: 'Meet Top Builders',
+      description: 'Top entries show rank, XP, completed challenges, badges, and recent rank movement.',
+    },
+    {
+      target: '#leaderboard-list',
+      title: 'Inspect Rankings',
+      description: 'Select a profile from the rankings to learn from other builders and their progress.',
+    },
+    {
+      target: '#leaderboard-stats',
+      title: 'Track Shared Momentum',
+      description: 'Community totals summarize XP, completed challenges, and badges earned across the platform.',
+    },
+  ],
+  profile: [
+    {
+      target: '#profile-summary-card',
+      title: 'Manage Your Identity',
+      description: 'Update your avatar, username, bio, and GitHub details so your profile reflects your work.',
+    },
+    {
+      target: '#profile-stats-card',
+      title: 'Review Account Stats',
+      description: 'Track XP, badges, role, and completed challenges from your profile sidebar.',
+    },
+    {
+      target: '#profile-submissions-card',
+      title: 'Audit Your Submissions',
+      description: 'Your submissions history keeps challenge status and feedback close when you revisit your work.',
+    },
+    {
+      target: '#profile-badges-card',
+      title: 'View Earned Badges',
+      description: 'Badges help tell the story of what you have completed and where you are growing.',
+    },
+    {
+      target: '#profile-settings-card',
+      title: 'Restart Tours Anytime',
+      description: 'Use Profile settings to restart onboarding tours whenever you want a fresh walkthrough.',
+    },
+  ],
+};
+
+export function getOnboardingPageKey(pathname: string): OnboardingPageKey | null {
+  if (pathname === '/dashboard') return 'dashboard';
+  if (pathname === '/learn') return 'learn';
+  if (pathname === '/challenges') return 'challenges';
+  if (pathname === '/leaderboard') return 'leaderboard';
+  if (pathname === '/profile') return 'profile';
+  return null;
+}

--- a/src/components/onboarding/onboardingStorage.ts
+++ b/src/components/onboarding/onboardingStorage.ts
@@ -1,0 +1,61 @@
+import { onboardingPageKeys, type OnboardingPageKey } from './onboardingSteps';
+
+export const ONBOARDING_RESTART_EVENT = 'nocodejam:onboarding-restart';
+
+export type OnboardingStatus = 'in-progress' | 'completed' | 'skipped';
+
+export interface StoredOnboardingProgress {
+  status: OnboardingStatus;
+  currentStep: number;
+}
+
+const STORAGE_PREFIX = 'nocodejam:onboarding';
+
+export function onboardingStorageKey(userId: string, pageKey: OnboardingPageKey) {
+  return `${STORAGE_PREFIX}:${userId}:${pageKey}`;
+}
+
+export function readOnboardingProgress(userId: string, pageKey: OnboardingPageKey) {
+  try {
+    const raw = window.localStorage.getItem(onboardingStorageKey(userId, pageKey));
+    if (!raw) return null;
+    return JSON.parse(raw) as StoredOnboardingProgress;
+  } catch {
+    return null;
+  }
+}
+
+export function writeOnboardingProgress(
+  userId: string,
+  pageKey: OnboardingPageKey,
+  progress: StoredOnboardingProgress
+) {
+  try {
+    window.localStorage.setItem(onboardingStorageKey(userId, pageKey), JSON.stringify(progress));
+  } catch {
+    // localStorage can be unavailable in private browsing or test environments.
+  }
+}
+
+export function skipAllOnboardingTours(userId: string) {
+  onboardingPageKeys.forEach((pageKey) => {
+    writeOnboardingProgress(userId, pageKey, { status: 'skipped', currentStep: 0 });
+  });
+}
+
+export function skipOnboardingPage(userId: string, pageKey: OnboardingPageKey, currentStep = 0) {
+  writeOnboardingProgress(userId, pageKey, {
+    status: 'skipped',
+    currentStep,
+  });
+}
+
+export function restartAllOnboardingTours(userId: string) {
+  try {
+    onboardingPageKeys.forEach((pageKey) => {
+      window.localStorage.removeItem(onboardingStorageKey(userId, pageKey));
+    });
+  } catch {
+    // Ignore unavailable storage.
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -511,3 +511,60 @@ html, body, #root {
 .animate-success-pulse {
   animation: success-pulse 0.6s ease-in-out;
 }
+
+.onboarding-overlay {
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-bg) 86%, transparent),
+      color-mix(in srgb, var(--gradient-purple) 34%, transparent)
+    );
+  backdrop-filter: blur(4px);
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.onboarding-spotlight {
+  background: transparent;
+  border: 2px solid var(--color-accent);
+  box-shadow:
+    0 0 0 1px var(--color-bg),
+    0 0 28px color-mix(in srgb, var(--color-accent) 54%, transparent);
+  pointer-events: none;
+  transition: top 240ms ease, left 240ms ease, width 240ms ease, height 240ms ease;
+}
+
+.onboarding-tooltip {
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+}
+
+.animate-onboarding-slide-down {
+  animation: onboarding-slide-down 220ms ease-out;
+}
+
+.animate-onboarding-slide-up {
+  animation: onboarding-slide-up 220ms ease-out;
+}
+
+@keyframes onboarding-slide-down {
+  from {
+    opacity: 0;
+    transform: translateY(-0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes onboarding-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/pages/ChallengeListPage.tsx
+++ b/src/pages/ChallengeListPage.tsx
@@ -162,7 +162,7 @@ export function ChallengeListPage() {
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
-        <div className="mb-8">
+        <div id="challenges-header" className="mb-8">
           <div className="flex justify-between items-start mb-4">
             <div>
               <h1 className="text-3xl font-bold text-white mb-2">Challenges</h1>
@@ -171,7 +171,7 @@ export function ChallengeListPage() {
               </p>
             </div>
             <ChallengeRequestModal>
-              <Button className="bg-purple-600 hover:bg-purple-700 text-white">
+              <Button id="challenge-request-button" className="bg-purple-600 hover:bg-purple-700 text-white">
                 <Plus className="w-4 h-4 mr-2" />
                 Request Challenge
               </Button>
@@ -180,7 +180,7 @@ export function ChallengeListPage() {
         </div>
 
         {/* Filters */}
-        <Card className="mb-8">
+        <Card id="challenge-filters-card" className="mb-8">
           <CardContent className="p-6">
             <div className="flex flex-col sm:flex-row gap-4">
               <div className="flex-1 relative">
@@ -210,7 +210,7 @@ export function ChallengeListPage() {
 
         {/* Challenge Grid */}
         {loading ? (
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div id="challenge-grid" className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
             {[1, 2, 3, 4, 5, 6].map(i => (
               <ChallengeCardSkeleton key={i} />
             ))}
@@ -243,7 +243,7 @@ export function ChallengeListPage() {
           )}
           
           {/* Regular Challenges Grid */}
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div id="challenge-grid" className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredChallenges.map((challenge) => {
             const status = getChallengeStatus(challenge.id);
             const requirementsArr = normalizeRequirements(challenge.requirements);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -49,7 +49,7 @@ export function Dashboard() {
     <main className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black">
       <div className="container-responsive py-6 sm:py-8">
         {/* Welcome Header */}
-        <header className="mb-6 sm:mb-8">
+        <header id="dashboard-welcome" className="mb-6 sm:mb-8">
           <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">
             Welcome back, {user.username}! 👋
           </h1>
@@ -62,7 +62,7 @@ export function Dashboard() {
           {/* Left Column - Stats & Progress */}
           <div className="lg:col-span-2 space-y-4 sm:space-y-6">
             {/* XP and Level Progress */}
-            <Card className="card-gradient-bar bg-gray-800 border-gray-700">
+            <Card id="xp-card" className="card-gradient-bar bg-gray-800 border-gray-700">
               <CardHeader>
                 <CardTitle className="flex items-center space-x-2 text-lg sm:text-xl text-white">
                   <Star className="w-5 h-5 text-yellow-500" />
@@ -97,7 +97,7 @@ export function Dashboard() {
             </Card>
 
             {/* Recent Submissions */}
-            <Card className="bg-gray-800 border-gray-700">
+            <Card id="recent-submissions-card" className="bg-gray-800 border-gray-700">
               <CardHeader>
                 <CardTitle className="text-lg sm:text-xl text-white">Recent Submissions</CardTitle>
                 <CardDescription className="text-gray-300">
@@ -154,7 +154,7 @@ export function Dashboard() {
           {/* Right Column - Profile & Badges */}
           <div className="space-y-4 sm:space-y-6">
             {/* Profile Card */}
-            <Card className="bg-gray-800 border-gray-700">
+            <Card id="dashboard-profile-card" className="bg-gray-800 border-gray-700">
               <CardHeader className="pb-2">
                 <CardTitle className="text-lg sm:text-xl text-white">Profile</CardTitle>
               </CardHeader>
@@ -191,7 +191,7 @@ export function Dashboard() {
             </Card>
 
             {/* Badges */}
-            <Card className="bg-gray-800 border-gray-700">
+            <Card id="dashboard-badges-card" className="bg-gray-800 border-gray-700">
               <CardHeader>
                 <CardTitle className="text-lg sm:text-xl text-white">Badges</CardTitle>
                 <CardDescription className="text-gray-300">

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -212,7 +212,7 @@ export function LeaderboardPage() {
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 relative z-10">
         {/* Header */}
-        <div className="text-center mb-8">
+        <div id="leaderboard-header" className="text-center mb-8">
           <h1 className="text-3xl font-bold text-white mb-2">🏆 Leaderboard</h1>
           <p className="text-gray-300">
             See how you rank against other no-code developers in the community
@@ -270,7 +270,7 @@ export function LeaderboardPage() {
             )}
 
             {/* Top 10 Leaderboard */}
-            <Card className="bg-gray-800 border-gray-700">
+            <Card id="top-10-card" className="bg-gray-800 border-gray-700">
               <CardHeader>
                 <CardTitle className="flex items-center space-x-2 text-white">
                   <Trophy className="w-6 h-6 text-yellow-500" />
@@ -281,7 +281,7 @@ export function LeaderboardPage() {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
+                <div id="leaderboard-list" className="space-y-4">
                   {leaderboard.slice(0, 10).map((developer, index) => {
                     const position = index + 1;
                     const isCurrentUser = developer.id === user?.id;
@@ -550,7 +550,7 @@ export function LeaderboardPage() {
             </Card>
 
             {/* Stats */}
-            <div className="grid md:grid-cols-3 gap-6 mt-8">
+            <div id="leaderboard-stats" className="grid md:grid-cols-3 gap-6 mt-8">
               <Card className="shadow-lg hover:shadow-xl transition-shadow bg-gray-800 border-gray-700">
                 <CardContent className="p-6 text-center">
                   <div className="text-3xl font-bold text-purple-400 mb-2">

--- a/src/pages/LearnPage.tsx
+++ b/src/pages/LearnPage.tsx
@@ -867,7 +867,7 @@ export function LearnPage() {
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
         {/* Header */}
-        <div className="text-center mb-6">
+        <div id="learn-header" className="text-center mb-6">
           <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight">
             <span className="mr-2">🎓</span>Explore No-Code Platforms for Fast Prototyping
           </h1>
@@ -878,8 +878,8 @@ export function LearnPage() {
         </div>
 
         {/* View mode toggle */}
-        <div className="flex justify-center mb-8">
-          <div className="inline-flex rounded-full border border-white/10 bg-white/[0.03] p-1">
+        <div id="learn-mode-toggle" className="flex justify-center mb-8">
+          <div id="learn-mode-buttons" className="inline-flex rounded-full border border-white/10 bg-white/[0.03] p-1">
             <button
               type="button"
               onClick={() => setFiltersMode('on')}
@@ -906,9 +906,9 @@ export function LearnPage() {
         {filtersMode === 'off' ? (
           <>
             {/* Classic controls (from old main) */}
-            <div className="mb-6 space-y-3">
+            <div id="learn-controls" className="mb-6 space-y-3">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                <div className="flex items-center gap-2 flex-wrap">
+                <div id="learn-path-buttons" className="flex items-center gap-2 flex-wrap">
                   <Button
                     variant="outline"
                     className="border-white/15 text-black/80 hover:bg-white/10"
@@ -989,7 +989,7 @@ export function LearnPage() {
             </div>
 
             {/* Classic platform grid */}
-            <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div id="learn-platforms" className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
               {classicFiltered.map((p) => (
                 <Card
                   key={p.id}
@@ -1040,7 +1040,7 @@ export function LearnPage() {
 
             {/* Classic details */}
             {selected && (
-              <div className="mt-10" ref={(el) => (platformRefs.current[selected.id] = el)}>
+              <div id="learn-selected-tool" className="mt-10" ref={(el) => (platformRefs.current[selected.id] = el)}>
                 <Card className="bg-white/[0.03] border-white/10 backdrop-blur-md">
                   <CardHeader>
                     <div className="flex items-center gap-4">
@@ -1150,7 +1150,7 @@ export function LearnPage() {
         ) : (
           <>
             {/* Quick category buttons */}
-            <div className="flex flex-wrap justify-center gap-3 mb-8">
+            <div id="learn-path-buttons" className="flex flex-wrap justify-center gap-3 mb-8">
               {['All', 'Visual Builder', 'AI-Powered', 'Web Development', 'Database'].map((cat) => (
                 <button
                   key={cat}
@@ -1163,7 +1163,7 @@ export function LearnPage() {
             </div>
 
         {/* Control Panel */}
-        <Card className="bg-white/[0.03] border-white/10 backdrop-blur-md shadow-xl">
+        <Card id="learn-controls" className="bg-white/[0.03] border-white/10 backdrop-blur-md shadow-xl">
           <CardHeader className="pb-4">
             <CardTitle className="text-lg flex items-center gap-2">
               <Zap className="w-5 h-5 text-purple-300" />
@@ -1295,7 +1295,7 @@ export function LearnPage() {
         </Card>
 
         {/* Tool Grid */}
-        <div className="mt-8 grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div id="learn-platforms" className="mt-8 grid md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filtered.map((platform) => {
             const isSelected = selected?.id === platform.id;
             const isRecommended = recommendedIds.has(platform.id);
@@ -1382,7 +1382,7 @@ export function LearnPage() {
 
         {/* Selected tool details */}
         {selected && (
-          <div className="mt-10" ref={(el) => (platformRefs.current[selected.id] = el)}>
+          <div id="learn-selected-tool" className="mt-10" ref={(el) => (platformRefs.current[selected.id] = el)}>
             <Card className="bg-white/[0.03] border-white/10 backdrop-blur-md">
               <CardHeader>
                 <div className="flex items-center gap-4">

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -8,10 +8,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/hooks/use-toast';
-import { User, Github, Mail, Calendar, ExternalLink, Trophy } from 'lucide-react';
+import { Github, Calendar, ExternalLink, Trophy, RotateCcw } from 'lucide-react';
 import { supabase } from '@/lib/supabaseClient';
 import { Link, useParams } from 'react-router-dom';
 import { Badge } from '@/components/ui/badge';
+import { ONBOARDING_RESTART_EVENT, restartAllOnboardingTours } from '@/components/onboarding/onboardingStorage';
 
 export function ProfilePage() {
   const { user: currentUser, setUser } = useAuth();
@@ -269,6 +270,17 @@ export function ProfilePage() {
     setPreviewUrl(url);
   };
 
+  const handleRestartTour = () => {
+    if (!currentUser) return;
+
+    restartAllOnboardingTours(currentUser.id);
+    window.dispatchEvent(new CustomEvent(ONBOARDING_RESTART_EVENT));
+    toast({
+      title: "Onboarding restarted",
+      description: "Tours are ready to run again across Dashboard, Learn, Challenges, Leaderboard, and Profile.",
+    });
+  };
+
 
   // Only allow editing if viewing own profile
   const isOwnProfile = !id || id === currentUser?.id;
@@ -282,7 +294,7 @@ export function ProfilePage() {
           {/* Left Column: Profile Info & Stats */}
           <div className="space-y-6 lg:col-span-1">
             {/* Profile Card */}
-            <Card className="bg-gray-800 border-gray-700">
+            <Card id="profile-summary-card" className="bg-gray-800 border-gray-700">
               <CardHeader className="text-center">
                 <Avatar className="w-24 h-24 mx-auto mb-4">
                   <AvatarImage src={isEditing ? formData.avatar : user?.avatar} alt={user?.username} />
@@ -398,7 +410,7 @@ export function ProfilePage() {
               </CardHeader>
             </Card>
             {/* Account Stats */}
-            <Card className="bg-gray-800 border-gray-700">
+            <Card id="profile-stats-card" className="bg-gray-800 border-gray-700">
               <CardHeader>
                 <CardTitle className="text-white">Account Stats</CardTitle>
               </CardHeader>
@@ -423,12 +435,34 @@ export function ProfilePage() {
                 </div>
               </CardContent>
             </Card>
+
+            {isOwnProfile && (
+              <Card id="profile-settings-card" className="bg-gray-800 border-gray-700">
+                <CardHeader>
+                  <CardTitle className="text-white">Profile Settings</CardTitle>
+                  <CardDescription className="text-gray-300">
+                    Manage guidance and walkthrough preferences
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full justify-start"
+                    onClick={handleRestartTour}
+                  >
+                    <RotateCcw className="w-4 h-4 mr-2" />
+                    Restart Tour
+                  </Button>
+                </CardContent>
+              </Card>
+            )}
           </div>
 
           {/* Right Column: Submissions & Badges */}
           <div className="space-y-8 lg:col-span-2">
             {/* Submissions Section */}
-            <Card className="bg-gray-800 border-gray-700">
+            <Card id="profile-submissions-card" className="bg-gray-800 border-gray-700">
               <CardHeader>
                 <CardTitle className="text-white">Your Submissions</CardTitle>
                 <CardDescription className="text-gray-300">All your challenge submissions</CardDescription>
@@ -479,7 +513,7 @@ export function ProfilePage() {
               </CardContent>
             </Card>
             {/* Badges Section */}
-            <Card className="bg-gray-800 border-gray-700">
+            <Card id="profile-badges-card" className="bg-gray-800 border-gray-700">
               <CardHeader>
                 <CardTitle className="text-white">Badges</CardTitle>
                 <CardDescription className="text-gray-300">Your achievements and milestones</CardDescription>


### PR DESCRIPTION
Summary

Adds a reusable multi-page onboarding tooltip system for Dashboard, Learn, Challenges, Leaderboard, and Profile.

Changes

- Added route-aware onboarding tour controller
- Added reusable dark-mode `OnboardingTooltip`
- Added per-page onboarding step configuration
- Added spotlight overlay with background interaction blocking
- Added localStorage-based per-user/page progress tracking
- Supports next, back, finish, skip current page tour, and restart all tours
- Added “Restart Tour” option in Profile settings
- Added onboarding target anchors across supported pages
- Adjusted Learn tour highlights to outline only relevant button groups